### PR TITLE
Fix dark-mode code-block striping and composer pill hover

### DIFF
--- a/chatgpt.com.user.css
+++ b/chatgpt.com.user.css
@@ -344,7 +344,7 @@
 					}
 				}
 
-			button.__composer-pill--neutral[data-state="open"],
+			button.__composer-pill--neutral[data-state=open],
 			button.__composer-pill--neutral[data-is-open] {
    				background-color: var(--interactive-bg-secondary-hover);
 			}

--- a/chatgpt.com.user.css
+++ b/chatgpt.com.user.css
@@ -337,12 +337,12 @@
 				/* April 2026: Voice Mode "End" button */
 			}
 			
-				@media (hover: hover) and (pointer: fine) {
-					button.__composer-pill--neutral:hover {
-						background-color: var(--interactive-bg-secondary-hover);
-						/* Composer neutral pills (model selector) - match the icon-button hover */
-					}
+			@media (hover: hover) and (pointer: fine) {
+				button.__composer-pill--neutral:hover {
+					background-color: var(--interactive-bg-secondary-hover);
+					/* Composer neutral pills (model selector) - match the icon-button hover */
 				}
+			}
 
 			button.__composer-pill--neutral[data-state=open],
 			button.__composer-pill--neutral[data-is-open] {

--- a/chatgpt.com.user.css
+++ b/chatgpt.com.user.css
@@ -337,12 +337,12 @@
 				/* April 2026: Voice Mode "End" button */
 			}
 			
-			@media (hover: hover) and (pointer: fine) {
-    			button.__composer-pill--neutral:hover {
-        			background-color: var(--interactive-bg-secondary-hover);
-					/* Composer neutral pills (model selector) - match the icon-button hover */
-    			}
-			}
+				@media (hover: hover) and (pointer: fine) {
+					button.__composer-pill--neutral:hover {
+						background-color: var(--interactive-bg-secondary-hover);
+						/* Composer neutral pills (model selector) - match the icon-button hover */
+					}
+				}
 
 			button.__composer-pill--neutral[data-state="open"],
 			button.__composer-pill--neutral[data-is-open] {

--- a/chatgpt.com.user.css
+++ b/chatgpt.com.user.css
@@ -250,7 +250,7 @@
 
 			:is(.dark, .light) .dark\:prose-invert :where(code):not(:where([class~=not-prose] *)):not(:where(pre *)) {
 				background-color: var(--disabled-button-bg);
-				/* Codeblock*/ 
+				/* Codeblock */ 
 				/* FIX: Exclude all <pre> descendants so block lines keep ChatGPT's 
 					transparent reset; old whitespace-pre! exclusion missed per-line <code> nodes */
 			}

--- a/chatgpt.com.user.css
+++ b/chatgpt.com.user.css
@@ -248,9 +248,11 @@
 				}
 			}
 
-			:is(.dark, .light) .dark\:prose-invert :where(code):not(:where([class~=not-prose] *)):not([class*="whitespace-pre!"]) {
+			:is(.dark, .light) .dark\:prose-invert :where(code):not(:where([class~=not-prose] *)):not(:where(pre *)) {
 				background-color: var(--disabled-button-bg);
-				/* Codeblock */
+				/* Codeblock*/ 
+				/* FIX: Exclude all <pre> descendants so block lines keep ChatGPT's 
+					transparent reset; old whitespace-pre! exclusion missed per-line <code> nodes */
 			}
 
 			.bg-token-bg-primary {
@@ -333,5 +335,17 @@
 			div[class="flex flex-row gap-2"] > button[aria-label] {
 				background: var(--primary-color);
 				/* April 2026: Voice Mode "End" button */
+			}
+			
+			@media (hover: hover) and (pointer: fine) {
+    			button.__composer-pill--neutral:hover {
+        			background-color: var(--interactive-bg-secondary-hover);
+					/* Composer neutral pills (model selector) - match the icon-button hover */
+    			}
+			}
+
+			button.__composer-pill--neutral[data-state="open"],
+			button.__composer-pill--neutral[data-is-open] {
+   				background-color: var(--interactive-bg-secondary-hover);
 			}
 		}

--- a/chatgpt.com.user.css
+++ b/chatgpt.com.user.css
@@ -346,6 +346,6 @@
 
 			button.__composer-pill--neutral[data-state=open],
 			button.__composer-pill--neutral[data-is-open] {
-   				background-color: var(--interactive-bg-secondary-hover);
+				background-color: var(--interactive-bg-secondary-hover);
 			}
 		}


### PR DESCRIPTION
Two dark-mode rendering fixes:

- **Code blocks:** replaced the stale `whitespace-pre!` exclusion with `:not(:where(pre *))` so per-line `<code>` nodes inside `<pre>` stop overriding ChatGPT's transparent reset (was causing striped line backgrounds).

- **Composer neutral pills (model selector):** native dark hover overrides the shared `--interactive-bg-secondary-hover` token with opaque `--bg-secondary`, so the pill didn't match the mic/icon buttons. Added a rule pointing it back at the shared token.

Firefox, June 2026.